### PR TITLE
Obtém autores de emendas e PECs diretamente da API

### DIFF
--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -713,23 +713,30 @@ fetch_autores <- function(proposicao_id = NULL, casa, sigla_tipo = "") {
   autor_uri <- paste0(.CAMARA_PROPOSICOES_PATH, '/', proposicao_id, "/autores")
   autores_info <- .camara_api(autor_uri) %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(id_autor = dplyr::if_else(!is.na(uri),
-                                            stringr::str_split(uri, '/')[[1]] %>%
-                                              dplyr::last() %>%
-                                              as.numeric(),-1),
+    dplyr::mutate(id_autor = purrr::map_dbl(uri, ~ .extract_id_autor_from_uri(.x)),
                   uri = dplyr::if_else(!is.na(uri), as.character(uri), "")) %>%
     dplyr::ungroup() %>%
+    dplyr::filter(proponente == 1) %>% 
     dplyr::select(id_autor, nome, cod_tipo = codTipo, tipo, uri)
-  if(sigla_tipo %in% c("EMC","PEC")){
-    scrap_df <- tibble::tibble(nome = scrap_autores_from_website(proposicao_id)) %>%
-      tidyr::separate_rows(nome, sep=", ") %>%
-      tidyr::separate(nome, c("nome","partido_uf"), sep=' - ', extra = "drop", fill = "right") %>%
-      dplyr::select(-partido_uf)
-    autores_info <- autores_info %>%
-      dplyr::inner_join(scrap_df, by = "nome")
-  }
-
   return(autores_info)
+}
+
+.extract_id_autor_from_uri <- function(uri_autor) {
+  id_autor <- -1
+  if ((!is.na(uri_autor))) {
+    tryCatch({
+      extracted_id_autor <- stringr::str_split(uri_autor, '/')[[1]] %>% 
+        dplyr::last() %>%
+        as.numeric()
+      if (!is.na(extracted_id_autor)) {
+        id_autor <- extracted_id_autor
+      }
+    },
+    error=function(msg){
+      warning(msg)
+    })
+  }
+  return(id_autor)
 }
 
 

--- a/tests/testthat/test_proposicoes.R
+++ b/tests/testthat/test_proposicoes.R
@@ -173,6 +173,14 @@ test_that(".fetch_autores_camara()",{
     ), emc_2206183)
 })
 
+test_that(".extract_id_autor_from_uri() works as expected",{
+  expect_equal(.extract_id_autor_from_uri(""),-1)
+  expect_equal(.extract_id_autor_from_uri(NA),-1)
+  expect_equal(.extract_id_autor_from_uri("NA"),-1)
+  expect_equal(.extract_id_autor_from_uri("NA/123"),123)
+  expect_equal(.extract_id_autor_from_uri("https://dadosabertos.camara.leg.br/api/v2/deputados/204371"),204371)
+})
+
 test_that(".scrap_senado_relacionadas_ids_from_website()", {
   pls_ids <- c(96123, 91341, 112563, 104930, 90919)
 


### PR DESCRIPTION
## Mudanças
- Remove chamada a função de scrap dos autores da Câmara da função .fetch_autores_camara
- Refatora o código, criando função auxiliar para extrair o id_autor a partir da URI do autor
- Cria testes para a função auxiliar adicionada

## Flags
- Um teste possível é com a emenda cujo id é 2206183. A API retorna vários autores, mas o código deve retornar apenas os proponentes: Rigoni e Tabata.