### PR TITLE
Adiciona comportamento de back-off exponencial para quando houver exceções de código

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -54,9 +54,9 @@ setup_cache <- function (name) {
     }
 
     if (is.null(value)) {
-        print(c("Not in cache", .cache_file_path))
+        cat("\nNot in cache")
     } else {
-        print(c("In cache", .cache_file_path))
+        cat("\nIn cache")
     }
     return(value)
 }

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -79,18 +79,26 @@ test_that(".unnest_df_column returns correct result", {
 
 test_that(".get_with_exponential_backoff_cached does not apply exponential backoff when response code is 404", {
   start_time <- Sys.time()
-  tryCatch({
-    .get_with_exponential_backoff_cached(base_url="https://dadosabertos.camara.leg.br",
+  
+  expect_error(.get_with_exponential_backoff_cached(base_url="https://dadosabertos.camara.leg.br",
                                          path='/api/v2/proposicoes/-1',
                                          base_sleep_time=1,
-                                         max_attempts=1)
-  }, warning = function(w) {
-  }, error = function(e) {
-  }, finally = {
-    end_time <- Sys.time()  
-  })
-  
+                                         max_attempts=1))
+  end_time <- Sys.time()  
   elapsed_time <- end_time - start_time
   
   expect_true(elapsed_time < 3)
+})
+
+test_that(".get_with_exponential_backoff_cached applies exponential backoff when there is an exception during request", {
+  start_time <- Sys.time()
+  
+  expect_error(.get_with_exponential_backoff_cached(base_url="https://-1",
+                                         path='',
+                                         base_sleep_time=2,
+                                         max_attempts=3))
+  end_time <- Sys.time()
+  elapsed_time <- end_time - start_time
+  
+  expect_true(elapsed_time > 4)
 })


### PR DESCRIPTION
## Mudanças
- Adiciona tolerância a falhas no nível de exceção do código à requisição, utilizando back-off exponencial. 
- Melhora log dos erros/tentativas do back-off exponencial.
- Adiciona teste para novo caso de uso (back-off exponencial em caso de exceção no código da requisição) e melhora testes existentes do arquivo utils.
- Melhora log de checagem de recurso na cache, tornando-o menos verborrágico.
- Corrige typo no parâmetro da chamada da função .get_from_cache, que fazia com que nunca o recurso estivesse na cache.
- Obs: Esse PR será muito últi para quando a API da Câmara ficar instável, dando erros de timeout =)

## Como Testar
- Deve-se tentar acessar uma URL inexistente ou modificar os parâmetros de chamada da função .get_with_exponential_backoff_cached para causar uma exceção de código.
