### PR TITLE
Conserta problema quando a proposição possui mais de uma situação

### DIFF
--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -51,28 +51,37 @@ fetch_proposicao <- function(proposicao_id = NULL, casa) {
 #'  \code{\link[rcongresso]{fetch_tipo_proposicao}}, \code{\link[rcongresso]{fetch_id_proposicao_camara}}
 #' @rdname fetch_proposicao_camara
 #' @export
-fetch_proposicao_camara <- function(id = NULL, siglaUfAutor = NULL, siglaTipo = NULL,
-                                    siglaPartidoAutor = NULL, numero = NULL, ano = NULL,
-                                    dataApresentacaoInicio = NULL, dataApresentacaoFim = NULL,
-                                    dataInicio = NULL, dataFim = NULL, idAutor = NULL,
-                                    autor = NULL, codPartido = NULL, itens = NULL) {
-
-  parametros <- as.list(environment(), all=TRUE)
-
-  if ( !length(.verifica_parametros_entrada(parametros))) {
-    .camara_api(.CAMARA_PROPOSICOES_PATH) %>%
-      .assert_dataframe_completo(.COLNAMES_PROPOSICAO_CAMARA) %>%
-      .coerce_types(.COLNAMES_PROPOSICAO_CAMARA)
-  } else if ( is.null(id)) {
-    .fetch_using_queries(parametros, .CAMARA_PROPOSICOES_PATH)%>%
-      .assert_dataframe_completo(.COLNAMES_PROPOSICAO_CAMARA) %>%
-      .coerce_types(.COLNAMES_PROPOSICAO_CAMARA)
-  } else {
-    .fetch_using_id(id, .CAMARA_PROPOSICOES_PATH)%>%
-      .assert_dataframe_completo(.COLNAMES_PROPOSICAO_POR_ID_CAMARA) %>%
-      .coerce_types(.COLNAMES_PROPOSICAO_POR_ID_CAMARA)
+fetch_proposicao_camara <-
+  function(id = NULL,
+           siglaUfAutor = NULL,
+           siglaTipo = NULL,
+           siglaPartidoAutor = NULL,
+           numero = NULL,
+           ano = NULL,
+           dataApresentacaoInicio = NULL,
+           dataApresentacaoFim = NULL,
+           dataInicio = NULL,
+           dataFim = NULL,
+           idAutor = NULL,
+           autor = NULL,
+           codPartido = NULL,
+           itens = NULL) {
+    parametros <- as.list(environment(), all = TRUE)
+    
+    if (!length(.verifica_parametros_entrada(parametros))) {
+      .camara_api(.CAMARA_PROPOSICOES_PATH) %>%
+        .assert_dataframe_completo(.COLNAMES_PROPOSICAO_CAMARA) %>%
+        .coerce_types(.COLNAMES_PROPOSICAO_CAMARA)
+    } else if (is.null(id)) {
+      .fetch_using_queries(parametros, .CAMARA_PROPOSICOES_PATH) %>%
+        .assert_dataframe_completo(.COLNAMES_PROPOSICAO_CAMARA) %>%
+        .coerce_types(.COLNAMES_PROPOSICAO_CAMARA)
+    } else {
+      .fetch_using_id(id, .CAMARA_PROPOSICOES_PATH) %>%
+        .assert_dataframe_completo(.COLNAMES_PROPOSICAO_POR_ID_CAMARA) %>%
+        .coerce_types(.COLNAMES_PROPOSICAO_POR_ID_CAMARA)
+    }
   }
-}
 
 #' @title Fetches a proposition in the Senate
 #' @description Returns the proposition info
@@ -89,54 +98,64 @@ fetch_proposicao_camara <- function(id = NULL, siglaUfAutor = NULL, siglaTipo = 
 #' @rdname fetch_proposicao_senado_sigla
 #' @export
 fetch_proposicao_senado_sigla <- function(sigla, numero, ano) {
-  if (.warnings_props_sigla(sigla, numero, ano)) return(tibble::tibble())
-
-  proposicao_data <- .senado_api(.SENADO_PROPOSICAO_PATH_SIGLA, query = list(sigla = sigla, numero = numero, ano = ano), asList = TRUE)
-
+  if (.warnings_props_sigla(sigla, numero, ano))
+    return(tibble::tibble())
+  
+  proposicao_data <-
+    .senado_api(
+      .SENADO_PROPOSICAO_PATH_SIGLA,
+      query = list(
+        sigla = sigla,
+        numero = numero,
+        ano = ano
+      ),
+      asList = TRUE
+    )
+  
   proposicao_infos <-
     proposicao_data %>%
     magrittr::extract2("PesquisaBasicaMateria") %>%
     magrittr::extract2("Materias") %>%
     magrittr::extract2("Materia")
-
+  
   proposicao_identificacao <-
     proposicao_infos %>%
     magrittr::extract2("IdentificacaoMateria") %>%
     tibble::as_tibble()
-
+  
   proposicao_dados_basicos <-
     proposicao_infos %>%
     magrittr::extract2("DadosBasicosMateria")
-
-  if("IdentificacaoComissaoMpv" %in% names(proposicao_dados_basicos)) {
+  
+  if ("IdentificacaoComissaoMpv" %in% names(proposicao_dados_basicos)) {
     proposicao_dados_basicos$IdentificacaoComissaoMpv <- NULL
   }
-
+  
   proposicao_dados_basicos <-
     proposicao_dados_basicos %>%
     tibble::as_tibble()
-
+  
   proposicao_natureza <- tibble::tibble()
   if ("NaturezaMateria" %in% names(proposicao_dados_basicos)) {
     proposicao_dados_basicos <-
       proposicao_dados_basicos %>%
       dplyr::select(-NaturezaMateria) %>%
       unique()
-
+    
     proposicao_natureza <-
       proposicao_infos %>%
       magrittr::extract2("DadosBasicosMateria") %>%
       magrittr::extract2("NaturezaMateria") %>%
       tibble::as_tibble()
   }
-
+  
   proposicao_autores <-
     proposicao_infos %>%
     magrittr::extract2("AutoresPrincipais") %>%
     magrittr::extract2("AutorPrincipal") %>%
     tibble::as_tibble() %>%
     head(1)
-
+  
   if ("IdentificacaoParlamentar" %in% names(proposicao_autores)) {
     proposicao_autores <-
       proposicao_autores %>%
@@ -144,7 +163,7 @@ fetch_proposicao_senado_sigla <- function(sigla, numero, ano) {
       unique() %>%
       head(1)
   }
-
+  
   proposicao_complete <-
     proposicao_identificacao %>%
     tibble::add_column(!!!proposicao_dados_basicos,
@@ -153,7 +172,7 @@ fetch_proposicao_senado_sigla <- function(sigla, numero, ano) {
     .rename_df_columns() %>%
     .assert_dataframe_completo(.COLNAMES_PROPOSICAO_SENADO_SIGLA) %>%
     .coerce_types(.COLNAMES_PROPOSICAO_SENADO_SIGLA)
-
+  
 }
 
 #' @title Fetches a proposition in the Senate
@@ -165,78 +184,93 @@ fetch_proposicao_senado_sigla <- function(sigla, numero, ano) {
 #' @rdname fetch_proposicao_senado
 #' @export
 fetch_proposicao_senado <- function(id = NULL) {
-  proposicao_data <- .senado_api(paste0(.SENADO_PROPOSICAO_PATH, id), asList = TRUE)$DetalheMateria$Materia
-
+  proposicao_data <-
+    .senado_api(paste0(.SENADO_PROPOSICAO_PATH, id), asList = TRUE)$DetalheMateria$Materia
+  
   proposicao_ids <-
     proposicao_data %>%
     magrittr::extract2("IdentificacaoMateria") %>%
     tibble::as_tibble()
-
+  
   proposicao_info <-
     proposicao_data %>%
     magrittr::extract2("DadosBasicosMateria") %>%
     purrr::flatten() %>%
     tibble::as_tibble()
-
+  
   proposicao_author <-
     proposicao_data %>%
     magrittr::extract2("Autoria") %>%
     magrittr::extract2("Autor") %>%
     tibble::as_tibble() %>%
     dplyr::rowwise() %>%
-    dplyr::transmute(
-      autor = paste(
-        paste(NomeAutor,
-              ifelse("IdentificacaoParlamentar.SiglaPartidoParlamentar" %in% names(.),
-                     IdentificacaoParlamentar.SiglaPartidoParlamentar, "")),
-        ifelse("UfAutor" %in% names(.), paste("/", UfAutor), "")))
-
+    dplyr::transmute(autor = paste(
+      paste(
+        NomeAutor,
+        ifelse(
+          "IdentificacaoParlamentar.SiglaPartidoParlamentar" %in% names(.),
+          IdentificacaoParlamentar.SiglaPartidoParlamentar,
+          ""
+        )
+      ),
+      ifelse("UfAutor" %in% names(.), paste("/", UfAutor), "")
+    ))
+  
   proposicao_situacao <- tibble::tibble()
   if ("SituacaoAtual" %in% names(proposicao_data)) {
-    proposicao_situacao<-
-      proposicao_data %>%
-      magrittr::extract2("SituacaoAtual") %>%
-      magrittr::extract2("Autuacoes") %>%
-      magrittr::extract2("Autuacao") %>%
-      purrr::flatten() %>%
-      tibble::as_tibble()
+    proposicao_situacao <-
+      (
+        proposicao_data %>%
+          magrittr::extract2("SituacaoAtual") %>%
+          magrittr::extract2("Autuacoes") %>%
+          magrittr::extract2("Autuacao")
+      )$Situacoes[[1]] %>%
+      tibble::as_tibble() %>%
+      dplyr::arrange(desc(`DataSituacao`)) %>%
+      head(1)
   }
-
+  
   proposicao_specific_assunto <-
     proposicao_data$Assunto$AssuntoEspecifico %>%
     tibble::as_tibble()
   if (nrow(proposicao_specific_assunto) == 0) {
     proposicao_specific_assunto <-
-      tibble::tribble(~ codigo_assunto_especifico, ~ assunto_especifico,
-                      0, "Nao especificado")
-  }else {
+      tibble::tribble(~ codigo_assunto_especifico,
+                      ~ assunto_especifico,
+                      0,
+                      "Nao especificado")
+  } else {
     proposicao_specific_assunto <-
       proposicao_specific_assunto %>%
-      dplyr::rename(assunto_especifico = Descricao, codigo_assunto_especifico = Codigo)
+      dplyr::rename(assunto_especifico = Descricao,
+                    codigo_assunto_especifico = Codigo)
   }
   proposicao_general_assunto <-
     proposicao_data$Assunto$AssuntoGeral %>%
     tibble::as_tibble()
   if (nrow(proposicao_general_assunto) == 0) {
     proposicao_general_assunto <-
-      tibble::tribble(~ codigo_assunto_geral, ~ assunto_geral,
-                      0, "Nao especificado")
-  }else {
+      tibble::tribble(~ codigo_assunto_geral,
+                      ~ assunto_geral,
+                      0,
+                      "Nao especificado")
+  } else {
     proposicao_general_assunto <-
       proposicao_general_assunto %>%
-      dplyr::rename(assunto_geral = Descricao, codigo_assunto_geral = Codigo)
+      dplyr::rename(assunto_geral = Descricao,
+                    codigo_assunto_geral = Codigo)
   }
-
+  
   proposicao_source <-
     proposicao_data %>%
     magrittr::extract2("OrigemMateria") %>%
     tibble::as_tibble()
-
+  
   anexadas <-
     proposicao_data$MateriasAnexadas$MateriaAnexada$IdentificacaoMateria.CodigoMateria
   relacionadas <-
     proposicao_data$MateriasRelacionadas$MateriaRelacionada$IdentificacaoMateria.CodigoMateria
-
+  
   proposicao_complete <-
     proposicao_info %>%
     tibble::add_column(
@@ -245,15 +279,19 @@ fetch_proposicao_senado <- function(id = NULL) {
       !!!proposicao_general_assunto,
       !!!proposicao_source,
       !!!proposicao_situacao,
-      autor_nome = dplyr::if_else(nrow(proposicao_author) > 1, paste0(proposicao_author[[1]] %>% head(1), " e outros"),proposicao_author[[1]] %>% head(1)),
+      autor_nome = dplyr::if_else(
+        nrow(proposicao_author) > 1,
+        paste0(proposicao_author[[1]] %>% head(1), " e outros"),
+        proposicao_author[[1]] %>% head(1)
+      ),
       proposicoes_relacionadas = paste(relacionadas, collapse = " "),
       proposicoes_apensadas = paste(anexadas, collapse = " ")
     )
-
+  
   proposicao_complete <-
     proposicao_complete[,!sapply(proposicao_complete, is.list)] %>%
     rename_table_to_underscore()
-
+  
   proposicao_complete[, names(proposicao_complete) %in% names(.COLNAMES_PROPOSICAO_SENADO)] %>%
     .assert_dataframe_completo(.COLNAMES_PROPOSICAO_SENADO) %>%
     .coerce_types(.COLNAMES_PROPOSICAO_SENADO)
@@ -268,8 +306,9 @@ fetch_proposicao_senado <- function(id = NULL) {
 #' @rdname fetch_textos_proposicao_senado
 #' @export
 fetch_textos_proposicao_senado <- function(id) {
-  proposicao_data <- .senado_api(paste0(.SENADO_TEXTOS_MATERIA, id), asList = TRUE)$TextoMateria$Materia
-
+  proposicao_data <-
+    .senado_api(paste0(.SENADO_TEXTOS_MATERIA, id), asList = TRUE)$TextoMateria$Materia
+  
   if (is.null(proposicao_data$Textos)) {
     proposicao_complete <-
       tibble::as_tibble()
@@ -278,24 +317,25 @@ fetch_textos_proposicao_senado <- function(id) {
       proposicao_data %>%
       magrittr::extract2("IdentificacaoMateria") %>%
       tibble::as_tibble()
-
+    
     proposicao_texto <-
       proposicao_data %>%
       magrittr::extract2("Textos") %>%
       magrittr::extract2("Texto") %>%
       tibble::as_tibble()
-
+    
     proposicao_complete <-
       proposicao_texto %>%
-      tibble::add_column(
-        !!!proposicao_ids) %>%
+      tibble::add_column(!!!proposicao_ids) %>%
       dplyr::mutate(casa = 'senado') %>%
       .rename_df_columns() %>%
       unique()
-
+    
   }
-
-  return(proposicao_complete %>% .assert_dataframe_completo(.COLNAMES_DOCUMENTOS_SENADO) %>% .coerce_types(.COLNAMES_DOCUMENTOS_SENADO))
+  
+  return(
+    proposicao_complete %>% .assert_dataframe_completo(.COLNAMES_DOCUMENTOS_SENADO) %>% .coerce_types(.COLNAMES_DOCUMENTOS_SENADO)
+  )
 }
 
 #' @title Fetches all propositions related to a proposition
@@ -311,7 +351,7 @@ fetch_textos_proposicao_senado <- function(id) {
 #'   \code{\link[rcongresso]{fetch_id_proposicao_camara}}
 #' @rdname fetch_relacionadas_camara
 #' @export
-fetch_relacionadas <- function(casa, id_casa){
+fetch_relacionadas <- function(casa, id_casa) {
   casa <- tolower(casa)
   if (casa == "camara") {
     .fetch_relacionadas_camara(id_casa)
@@ -341,7 +381,7 @@ fetch_ids_relacionadas <- function(id, casa) {
                       id_prop) %>%
         dplyr::mutate(casa = "camara")
     }
-
+    
   } else if (casa == "senado") {
     relacionadas <- .fetch_relacionadas_senado(id)
     if (nrow(relacionadas) == 0) {
@@ -354,7 +394,7 @@ fetch_ids_relacionadas <- function(id, casa) {
   } else {
     warning("Parametro 'casa' nao identificado")
   }
-
+  
   return(relacionadas)
 }
 
@@ -366,16 +406,14 @@ fetch_ids_relacionadas <- function(id, casa) {
 #' @seealso
 #'   \code{\link[rcongresso]{fetch_id_proposicao_camara}}
 #' @rdname fetch_relacionadas_camara
-.fetch_relacionadas_camara <- function(id_prop){
+.fetch_relacionadas_camara <- function(id_prop) {
   path <- NULL
   unique(id_prop) %>%
     as.integer %>%
     tibble::tibble(id_prop = .) %>%
     dplyr::mutate(path = paste0(.CAMARA_PROPOSICOES_PATH, "/", id_prop, "/relacionadas")) %>%
     dplyr::group_by(id_prop, path) %>%
-    dplyr::do(
-      .camara_api(.$path)
-    ) %>%
+    dplyr::do(.camara_api(.$path)) %>%
     dplyr::ungroup() %>%
     dplyr::select(-path) %>%
     dplyr::distinct() %>% #Remove duplicate relacionadas
@@ -389,16 +427,20 @@ fetch_ids_relacionadas <- function(id, casa) {
 #' @return Dataframe containing all the related propositions.
 .fetch_relacionadas_senado <- function(id_prop) {
   relacionadas_api <- tibble::tibble()
-  relacionadas_website <- .scrap_senado_relacionadas_ids_from_website(id_prop) %>%
+  relacionadas_website <-
+    .scrap_senado_relacionadas_ids_from_website(id_prop) %>%
     dplyr::select(-url_relacionada)
-
+  
   relacionadas_prop <- fetch_proposicao_senado(id_prop)
   if (relacionadas_prop$proposicoes_relacionadas != "") {
     relacionadas_api <- tibble::tibble(id_relacionada =
-                                         unlist(strsplit(relacionadas_prop$proposicoes_relacionadas, " ")))
+                                         unlist(
+                                           strsplit(relacionadas_prop$proposicoes_relacionadas, " ")
+                                         ))
   }
-
-  relacionadas_all <- dplyr::bind_rows(relacionadas_api,relacionadas_website) %>%
+  
+  relacionadas_all <-
+    dplyr::bind_rows(relacionadas_api, relacionadas_website) %>%
     dplyr::distinct()
   return(relacionadas_all)
 }
@@ -418,15 +460,15 @@ fetch_ids_relacionadas <- function(id, casa) {
     rvest::html_nodes('td') %>%
     rvest::html_nodes('a') %>%
     rvest::html_attr('href') %>%
-    tibble::enframe(value="url_relacionada")
+    tibble::enframe(value = "url_relacionada")
   Sys.sleep(.DEF_SCRAP_SLEEP_TIME)
-
+  
   relacionadas_ids <- relacionadas_urls %>%
     dplyr::rowwise() %>%
     dplyr::mutate(id_relacionada = stringr::str_split(url_relacionada, "/") %>%
-                    purrr::pluck(1,9)) %>%
+                    purrr::pluck(1, 9)) %>%
     dplyr::select(-name)
-
+  
   return(relacionadas_ids)
 }
 
@@ -438,50 +480,58 @@ fetch_ids_relacionadas <- function(id, casa) {
 #' @return dataframe
 #' @rdname scrap_senado_congresso_documentos
 #' @export
-scrap_senado_congresso_documentos <- function(id_prop, casa, filter_texto_materia = F) {
-  if (is.na(filter_texto_materia)) {
-    warning("filter_texto_materia deve ser: T ou F.")
-    return(tibble::tibble())
-  }
-
-  if (!is.na(casa) & tolower(casa) == 'senado') {
-    documentos_df <-
-      .get_with_exponential_backoff_cached(paste0(.SENADO_WEBSITE_LINK, .MATERIA_SENADO_PATH, id_prop))
-  }else if (!is.na(casa) & tolower(casa) == 'congresso') {
-    documentos_df <-
-      .get_with_exponential_backoff_cached(paste0(.CONGRESSO_WEBSITE_LINK, .MATERIA_CONGRESSO_PATH, id_prop))
-  }else {
-    warning("Casa deve ser: congresso ou senado.")
-    return(tibble::tibble())
-  }
-
-  documentos_df <-
-    documentos_df %>%
-    httr::content('text', encoding = 'utf-8') %>%
-    xml2::read_html()  %>%
-    rvest::html_nodes('#conteudoProjeto') %>%
-    rvest::html_nodes('#documentos') %>%
-    rvest::html_nodes('.tab-content') %>%
-    rvest::html_nodes('dl')  %>%
-    purrr::map_df(.get_documento) %>%
-    unique() %>%
-    .rename_documentos_senado() %>%
-    dplyr::mutate(id_principal = id_prop,
-                  casa = 'senado')
-
-  if (filter_texto_materia) {
+scrap_senado_congresso_documentos <-
+  function(id_prop, casa, filter_texto_materia = F) {
+    if (is.na(filter_texto_materia)) {
+      warning("filter_texto_materia deve ser: T ou F.")
+      return(tibble::tibble())
+    }
+    
+    if (!is.na(casa) & tolower(casa) == 'senado') {
+      documentos_df <-
+        .get_with_exponential_backoff_cached(paste0(.SENADO_WEBSITE_LINK, .MATERIA_SENADO_PATH, id_prop))
+    } else if (!is.na(casa) & tolower(casa) == 'congresso') {
+      documentos_df <-
+        .get_with_exponential_backoff_cached(paste0(
+          .CONGRESSO_WEBSITE_LINK,
+          .MATERIA_CONGRESSO_PATH,
+          id_prop
+        ))
+    } else {
+      warning("Casa deve ser: congresso ou senado.")
+      return(tibble::tibble())
+    }
+    
     documentos_df <-
       documentos_df %>%
-      dplyr::filter(!stringr::str_detect(
-        .remove_special_character(identificacao),
-        "Texto inicial|Avulso inicial da materia|Redacao Final de Plenario|Texto final"))
+      httr::content('text', encoding = 'utf-8') %>%
+      xml2::read_html()  %>%
+      rvest::html_nodes('#conteudoProjeto') %>%
+      rvest::html_nodes('#documentos') %>%
+      rvest::html_nodes('.tab-content') %>%
+      rvest::html_nodes('dl')  %>%
+      purrr::map_df(.get_documento) %>%
+      unique() %>%
+      .rename_documentos_senado() %>%
+      dplyr::mutate(id_principal = id_prop,
+                    casa = 'senado')
+    
+    if (filter_texto_materia) {
+      documentos_df <-
+        documentos_df %>%
+        dplyr::filter(
+          !stringr::str_detect(
+            .remove_special_character(identificacao),
+            "Texto inicial|Avulso inicial da materia|Redacao Final de Plenario|Texto final"
+          )
+        )
+    }
+    
+    documentos_df %>%
+      .assert_dataframe_completo(.COLNAMES_SCRAP) %>%
+      .coerce_types(.COLNAMES_SCRAP) %>%
+      tibble::as_tibble()
   }
-
-  documentos_df %>%
-    .assert_dataframe_completo(.COLNAMES_SCRAP) %>%
-    .coerce_types(.COLNAMES_SCRAP) %>%
-    tibble::as_tibble()
-}
 
 
 #' @title Auxiliar function for scrap_senado_congresso_documentos
@@ -545,13 +595,21 @@ scrap_senado_congresso_documentos <- function(id_prop, casa, filter_texto_materi
 #'   \code{\link[rcongresso]{fetch_id_partido}}
 #' @rdname fetch_id_proposicao_camara
 #' @export
-fetch_id_proposicao_camara <- function(tipo, numero, ano){
+fetch_id_proposicao_camara <- function(tipo, numero, ano) {
   tibble::tibble(tipo, numero, ano) %>%
     dplyr::rowwise() %>%
     dplyr::do(
-      .camara_api(.CAMARA_PROPOSICOES_PATH,
-                  list(siglaTipo = .$tipo, numero = .$numero, ano = .$ano,
-                       ordem = "ASC", ordenarPor = "id", dataInicio = paste0(ano,"-01-01")))$id %>%
+      .camara_api(
+        .CAMARA_PROPOSICOES_PATH,
+        list(
+          siglaTipo = .$tipo,
+          numero = .$numero,
+          ano = .$ano,
+          ordem = "ASC",
+          ordenarPor = "id",
+          dataInicio = paste0(ano, "-01-01")
+        )
+      )$id %>%
         .verifica_id(.WARNING_PROPOSICAO_ID) %>%
         .to_tibble()
     ) %>%
@@ -564,7 +622,7 @@ fetch_id_proposicao_camara <- function(tipo, numero, ano){
 #' @return Proposition types
 #'
 #' @export
-fetch_tipos_proposicao <- function(){
+fetch_tipos_proposicao <- function() {
   .camara_api(.TIPOS_PROPOSICOES_PATH)
 }
 
@@ -576,10 +634,10 @@ fetch_tipos_proposicao <- function(){
 #' tipo_prop129 <- fetch_tipo_proposicao(129)
 #' @rdname fetch_tipo_proposicao
 #' @export
-fetch_tipo_proposicao <- function(id_tipo_prop){
+fetch_tipo_proposicao <- function(id_tipo_prop) {
   prop_types <- fetch_tipos_proposicao() %>%
     dplyr::mutate(cod = as.numeric(.$cod))
-
+  
   tibble::tibble(cod = id_tipo_prop) %>%
     dplyr::left_join(prop_types, by = "cod") %>%
     .assert_dataframe_completo(.COLNAMES_TIPO_PROPOSICAO) %>%
@@ -594,21 +652,22 @@ fetch_tipo_proposicao <- function(id_tipo_prop){
 #' fetch_autor_camara(2121442)
 #' @export
 fetch_autor_camara <- function (proposicao_id = NULL) {
-  autor_uri <- paste0(.CAMARA_PROPOSICOES_PATH, '/', proposicao_id, "/autores")
+  autor_uri <-
+    paste0(.CAMARA_PROPOSICOES_PATH, '/', proposicao_id, "/autores")
   autor_info <- .camara_api(autor_uri)
-  if(any(is.na(autor_info$uri))){
+  if (any(is.na(autor_info$uri))) {
     autores <- .camara_api(autor_uri) %>%
       .assert_dataframe_completo(.COLNAMES_AUTORES) %>%
       .coerce_types(.COLNAMES_AUTORES)
   } else {
-    autores <- purrr::map_df(autor_info$uri, ~.auxiliary_fetch_autor_camara(.x)) %>%
-      dplyr::left_join(
-        autor_info %>% dplyr::select(-nome),
-        by = "uri")
+    autores <-
+      purrr::map_df(autor_info$uri, ~ .auxiliary_fetch_autor_camara(.x)) %>%
+      dplyr::left_join(autor_info %>% dplyr::select(-nome),
+                       by = "uri")
   }
-
+  
   return(autores)
-
+  
 }
 
 #' @title Fetches proposition's authors
@@ -623,15 +682,18 @@ fetch_autor_camara <- function (proposicao_id = NULL) {
 #' fetch_autores(91341, 'senado')
 #' }
 #' @export
-fetch_autores <- function(proposicao_id = NULL, casa, sigla_tipo = "") {
-  if (casa == "camara") {
-    .fetch_autores_camara(proposicao_id, sigla_tipo)
-  } else if (casa == "senado") {
-    .fetch_autores_senado(proposicao_id)
-  } else {
-    return("Parametro 'casa' nao identificado.")
+fetch_autores <-
+  function(proposicao_id = NULL,
+           casa,
+           sigla_tipo = "") {
+    if (casa == "camara") {
+      .fetch_autores_camara(proposicao_id, sigla_tipo)
+    } else if (casa == "senado") {
+      .fetch_autores_senado(proposicao_id)
+    } else {
+      return("Parametro 'casa' nao identificado.")
+    }
   }
-}
 
 #' @title Fetches proposition's authors
 #' @description Fetches a dataframe containing basic information about the authors of the proposition
@@ -643,44 +705,80 @@ fetch_autores <- function(proposicao_id = NULL, casa, sigla_tipo = "") {
 #' }
 #' @export
 .fetch_autores_senado <- function(proposicao_id) {
-  autor_data <- .senado_api(paste0(.SENADO_PROPOSICAO_PATH, proposicao_id),
-                            asList = TRUE)$DetalheMateria$Materia$Autoria$Autor
-
+  autor_data <-
+    .senado_api(paste0(.SENADO_PROPOSICAO_PATH, proposicao_id),
+                asList = TRUE)$DetalheMateria$Materia$Autoria$Autor
+  
   autores_complete <-
     .rename_df_columns(autor_data)
-
-  if(ncol(autores_complete) < 6) {
+  
+  if (ncol(autores_complete) < 6) {
     autores_complete <- autores_complete %>%
-      dplyr::mutate(id_parlamentar = NA,
-                    uf_autor = NA,
-                    nome = NA,
-                    nome_completo = NA,
-                    sexo = NA,
-                    forma_de_tratamento = NA,
-                    url_foto = NA,
-                    url_pagina = NA,
-                    email = NA,
-                    sigla_partido = NA,
-                    uf_parlamentar = NA)
+      dplyr::mutate(
+        id_parlamentar = NA,
+        uf_autor = NA,
+        nome = NA,
+        nome_completo = NA,
+        sexo = NA,
+        forma_de_tratamento = NA,
+        url_foto = NA,
+        url_pagina = NA,
+        email = NA,
+        sigla_partido = NA,
+        uf_parlamentar = NA
+      )
   } else {
     autores_complete <- autores_complete %>%
-      dplyr::mutate(id_parlamentar = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_codigo_parlamentar'),
-                    nome = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_nome_parlamentar'),
-                    nome_completo = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_nome_completo_parlamentar'),
-                    sexo = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_sexo_parlamentar'),
-                    forma_de_tratamento = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_forma_tratamento'),
-                    url_foto = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_url_foto_parlamentar'),
-                    url_pagina = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_url_pagina_parlamentar'),
-                    email = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_email_parlamentar'),
-                    sigla_partido = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_sigla_partido_parlamentar'),
-                    uf_parlamentar = .safe_get_value_coluna(autores_complete,'identificacao_parlamentar_uf_parlamentar'))
+      dplyr::mutate(
+        id_parlamentar = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_codigo_parlamentar'
+        ),
+        nome = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_nome_parlamentar'
+        ),
+        nome_completo = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_nome_completo_parlamentar'
+        ),
+        sexo = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_sexo_parlamentar'
+        ),
+        forma_de_tratamento = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_forma_tratamento'
+        ),
+        url_foto = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_url_foto_parlamentar'
+        ),
+        url_pagina = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_url_pagina_parlamentar'
+        ),
+        email = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_email_parlamentar'
+        ),
+        sigla_partido = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_sigla_partido_parlamentar'
+        ),
+        uf_parlamentar = .safe_get_value_coluna(
+          autores_complete,
+          'identificacao_parlamentar_uf_parlamentar'
+        )
+      )
   }
-
-  unwanted_cols <- names(autores_complete)[startsWith(names(autores_complete), 'identificacao_parlamentar')]
-
+  
+  unwanted_cols <-
+    names(autores_complete)[startsWith(names(autores_complete), 'identificacao_parlamentar')]
+  
   autores_complete <- autores_complete %>%
     dplyr::select(-unwanted_cols)
-
+  
   autores_complete %>%
     .assert_dataframe_completo(.COLNAMES_AUTORES_SENADO) %>%
     .coerce_types(.COLNAMES_AUTORES_SENADO)
@@ -695,28 +793,42 @@ fetch_autores <- function(proposicao_id = NULL, casa, sigla_tipo = "") {
 #' \dontrun{
 #' .fetch_autores_camara(2121442)
 #' }
-.fetch_autores_camara <- function (proposicao_id = NULL, sigla_tipo = "" ) {
-  autor_uri <- paste0(.CAMARA_PROPOSICOES_PATH, '/', proposicao_id, "/autores")
-  autores_info <- .camara_api(autor_uri) %>%
-    dplyr::rowwise() %>%
-    dplyr::mutate(id_autor = dplyr::if_else(!is.na(uri),
-                                            stringr::str_split(uri, '/')[[1]] %>%
-                                              dplyr::last() %>%
-                                              as.numeric(),-1),
-                  uri = dplyr::if_else(!is.na(uri), as.character(uri), "")) %>%
-    dplyr::ungroup() %>%
-    dplyr::select(id_autor, nome, cod_tipo = codTipo, tipo, uri)
-  if(sigla_tipo %in% c("EMC","PEC")){
-    scrap_df <- tibble::tibble(nome = scrap_autores_from_website(proposicao_id)) %>%
-      tidyr::separate_rows(nome, sep=", ") %>%
-      tidyr::separate(nome, c("nome","partido_uf"), sep=' - ', extra = "drop", fill = "right") %>%
-      dplyr::select(-partido_uf)
-    autores_info <- autores_info %>%
-      dplyr::inner_join(scrap_df, by = "nome")
+.fetch_autores_camara <-
+  function (proposicao_id = NULL,
+            sigla_tipo = "") {
+    autor_uri <-
+      paste0(.CAMARA_PROPOSICOES_PATH, '/', proposicao_id, "/autores")
+    autores_info <- .camara_api(autor_uri) %>%
+      dplyr::rowwise() %>%
+      dplyr::mutate(
+        id_autor = dplyr::if_else(
+          !is.na(uri),
+          stringr::str_split(uri, '/')[[1]] %>%
+            dplyr::last() %>%
+            as.numeric(),-1
+        ),
+        uri = dplyr::if_else(!is.na(uri), as.character(uri), "")
+      ) %>%
+      dplyr::ungroup() %>%
+      dplyr::select(id_autor, nome, cod_tipo = codTipo, tipo, uri)
+    if (sigla_tipo %in% c("EMC", "PEC")) {
+      scrap_df <-
+        tibble::tibble(nome = scrap_autores_from_website(proposicao_id)) %>%
+        tidyr::separate_rows(nome, sep = ", ") %>%
+        tidyr::separate(
+          nome,
+          c("nome", "partido_uf"),
+          sep = ' - ',
+          extra = "drop",
+          fill = "right"
+        ) %>%
+        dplyr::select(-partido_uf)
+      autores_info <- autores_info %>%
+        dplyr::inner_join(scrap_df, by = "nome")
+    }
+    
+    return(autores_info)
   }
-
-  return(autores_info)
-}
 
 
 #' @title Scraps autores da proposicao from website
@@ -726,18 +838,23 @@ fetch_autores <- function(proposicao_id = NULL, casa, sigla_tipo = "") {
 #' @export
 scrap_autores_from_website <- function(id_prop) {
   autores_prop_text <-
-    .get_with_exponential_backoff_cached(paste0(.CAMARA_WEBSITE_LINK_2, .AUTORES_CAMARA_PATH, "?idProposicao=", id_prop))%>%
+    .get_with_exponential_backoff_cached(paste0(
+      .CAMARA_WEBSITE_LINK_2,
+      .AUTORES_CAMARA_PATH,
+      "?idProposicao=",
+      id_prop
+    )) %>%
     httr::content('text', encoding = 'utf-8') %>%
     xml2::read_html()  %>%
     rvest::html_nodes('#content') %>%
     rvest::html_nodes('span') %>%
     rvest::html_text()
   Sys.sleep(.DEF_SCRAP_SLEEP_TIME)
-
+  
   autores <- autores_prop_text[3:length(autores_prop_text)] %>%
     trimws(which = c("both")) %>%
     unique()
-
+  
   paste0(autores, collapse = ", ")
 }
 
@@ -761,30 +878,32 @@ scrap_autores_from_website <- function(id_prop) {
 #' fetch_apensadas_camara(2121442)
 #' @export
 fetch_apensadas_camara <- function(prop_id) {
-  .get_with_exponential_backoff_cached(.CAMARA_WEBSITE_LINK, .APENSADAS_CAMARA_PATH, paste0('idProp=', prop_id)) %>%
+  .get_with_exponential_backoff_cached(.CAMARA_WEBSITE_LINK,
+                                       .APENSADAS_CAMARA_PATH,
+                                       paste0('idProp=', prop_id)) %>%
     xml2::read_xml() %>%
     xml2::xml_find_all('//apensadas/proposicao/codProposicao') %>%
     xml2::xml_text()
 }
 
 #' @title Fetch the proposition's themes
-#' @description Returns a dataframe containing the themes of a proposition 
+#' @description Returns a dataframe containing the themes of a proposition
 #' @param prop_id Proposition's ID
-#' @return A dataframe containing the themes of a proposition 
+#' @return A dataframe containing the themes of a proposition
 #' @examples
 #' .fetch_temas_camara(2121442)
 .fetch_temas_camara <- function(prop_id) {
-  .camara_api(paste0(.CAMARA_PROPOSICOES_PATH, "/", prop_id, .TEMAS_PATH_CAMARA)) %>% 
+  .camara_api(paste0(.CAMARA_PROPOSICOES_PATH, "/", prop_id, .TEMAS_PATH_CAMARA)) %>%
     .rename_df_columns() %>%
     .assert_dataframe_completo(.COLNAMES_TEMAS_CAMARA) %>%
     .coerce_types(.COLNAMES_TEMAS_CAMARA)
 }
 
 #' @title Fetch the proposition's themes
-#' @description Returns a dataframe containing the themes of a proposition 
+#' @description Returns a dataframe containing the themes of a proposition
 #' @param proposicao_id Proposition's ID
 #' @param casa senado or camara
-#' @return A dataframe containing the themes of a proposition 
+#' @return A dataframe containing the themes of a proposition
 #' @examples
 #' fetch_temas_proposicao(2121442, "camara")
 #' @export


### PR DESCRIPTION
Mudanças propostas nesse PR:
- Resolve erro ao chamar a função `fetch_proposicao_senado` quando a proposição possui mais de uma situação, passando a usar apenas a mais recente (Ex: id 136531);
- Resolve erro quando a proposição retorna mais de uma tag Autuacao, retornando a mais recente;
- Resolve erro quando a proposição não tem Autor, apenas Iniciadores (ex: 142016);
- Ajusta indentação no arquivo.