### PR TITLE
Conserta erro em retorno de proposições por nome formal no senado

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -407,6 +407,21 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
   df
 }
 
+#' @title Renames propositions dataframe's columns
+#' @description Renames dataframe's columns using underscore and lowercase pattern and 
+#' removing unnecessary strings from column names.
+#' @param df Dataframe
+#' @return Dataframe with renamed columns.
+.rename_senate_propositions_df_columns <- function(df) {
+  names(df) <- 
+    stringr::str_remove_all(
+      names(df),
+      "IdentificacaoMateria\\.|DadosBasicosMateria\\.|NaturezaMateria\\.|AutoresPrincipais\\.AutorPrincipal\\.|SituacaoAtual\\.Autuacoes\\.Autuacao\\.|Situacoes\\.|LocalAdministrativo\\.")
+  
+  return(df %>% .rename_df_columns())
+  
+  }
+
 #' @title Renames a vector with the pattern of underscores and lowercases
 #' @description Renames each item from vector with the pattern: split by underscore and lowercase
 #' @param x Strings vector


### PR DESCRIPTION
**Mudanças propostas nesse PR:**
- Resolve problema em chamada de função que retorna a proposição por nome formal (no Senado).
- Ex: `fetch_proposicao_senado_sigla("mpv", 869, 2018)` e `fetch_proposicao_senado_sigla("vet", 24, 2019)`
