### PR TITLE
Analise de casa_origem

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -91,4 +91,4 @@
 
 .PODER_EXECUTIVO <- "poder executivo"
 .SENADO_FEDERAL <- "senado federal"
-.COMISSAO_LEGISLACAO_PARTICIPATIVA <- "comissão de legislação participativa"
+.COMISSAO <- "comissão"

--- a/R/constants.R
+++ b/R/constants.R
@@ -90,3 +90,4 @@
 .TIPOS_EMENDAS <- c("EMC" , "EMP" , "EMS" , "SBE" , "EMR" , "ESB" , "EMO" , "EMD" , "EPP" , "EAG" , "ESP" , "SSP" , "SAP" , "EMA" , "EMRP" , "EMC-A" , "SBE-A" , "EMPV" , "SBR" , "ERD-A")
 
 .PODER_EXECUTIVO <- "poder executivo"
+.SENADO_FEDERAL <- "senado federal"

--- a/R/constants.R
+++ b/R/constants.R
@@ -91,3 +91,4 @@
 
 .PODER_EXECUTIVO <- "poder executivo"
 .SENADO_FEDERAL <- "senado federal"
+.COMISSAO_LEGISLACAO_PARTICIPATIVA <- "comissão de legislação participativa"

--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -710,7 +710,7 @@ fetch_autor_camara <- function (proposicao_id = NULL) {
   autor_uri <-
     paste0(.CAMARA_PROPOSICOES_PATH, '/', proposicao_id, "/autores")
   autor_info <- .camara_api(autor_uri)
-  if (any(is.na(autor_info$uri)) | .check_autor_poder_executivo(autor_info)) {
+  if (any(is.na(autor_info$uri)) | .check_autor_poder_executivo(autor_info) | .check_autor_senado_federal(autor_info)) {
     autores <- .camara_api(autor_uri) %>%
       .assert_dataframe_completo(.COLNAMES_AUTORES) %>%
       .coerce_types(.COLNAMES_AUTORES)
@@ -940,6 +940,22 @@ scrap_autores_from_website <- function(id_prop) {
     nrow()
 
   return(autor_poder_executivo != 0)
+}
+
+#' @title Checks whether the federal senade is the author of the bill
+#' @description Checks whether the federal senade is the author of the bill
+#' @param autor_info Dataframe with information about the author
+#' @return True if the federal senade is the author of the proposition and FALSE otherwise
+#' @examples
+#' autor_uri <- paste0(.CAMARA_PROPOSICOES_PATH, '/', 2203836, "/autores")
+#' autor_info <- .camara_api(autor_uri)
+#' .check_autor_senado_federal(autor_info)
+.check_autor_senado_federal <- function(autor_info) {
+  autor_senado_federal <- autor_info %>%
+    dplyr::filter(stringr::str_detect(tolower(nome), .SENADO_FEDERAL)) %>%
+    nrow()
+  
+  return(autor_senado_federal != 0)
 }
 
 #' @title Fetch the propositions appended to a proposition in the Camara

--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -710,7 +710,12 @@ fetch_autor_camara <- function (proposicao_id = NULL) {
   autor_uri <-
     paste0(.CAMARA_PROPOSICOES_PATH, '/', proposicao_id, "/autores")
   autor_info <- .camara_api(autor_uri)
-  if (any(is.na(autor_info$uri)) | .check_autor_poder_executivo(autor_info) | .check_autor_senado_federal(autor_info)) {
+  
+  if (any(is.na(autor_info$uri)) |
+      .check_autor_poder_executivo(autor_info) |
+      .check_autor_senado_federal(autor_info) |
+      .check_autor_legislacao_participativa(autor_info)) {
+    
     autores <- .camara_api(autor_uri) %>%
       .assert_dataframe_completo(.COLNAMES_AUTORES) %>%
       .coerce_types(.COLNAMES_AUTORES)
@@ -956,6 +961,22 @@ scrap_autores_from_website <- function(id_prop) {
     nrow()
   
   return(autor_senado_federal != 0)
+}
+
+#' @title Checks whether the participatory legislation commission is the author of the bill
+#' @description Checks whether the participatory legislation commission is the author of the bill
+#' @param autor_info Dataframe with information about the author
+#' @return True if the participatory legislation commission is the author of the proposition and FALSE otherwise
+#' @examples
+#' autor_uri <- paste0(.CAMARA_PROPOSICOES_PATH, '/', 2203836, "/autores")
+#' autor_info <- .camara_api(autor_uri)
+#' .check_autor_legislacao_participativa(autor_info)
+.check_autor_legislacao_participativa <- function(autor_info) {
+  autor_legislacao_participativa <- autor_info %>%
+    dplyr::filter(stringr::str_detect(tolower(nome), .COMISSAO_LEGISLACAO_PARTICIPATIVA)) %>%
+    nrow()
+  
+  return(autor_legislacao_participativa != 0)
 }
 
 #' @title Fetch the propositions appended to a proposition in the Camara

--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -714,7 +714,7 @@ fetch_autor_camara <- function (proposicao_id = NULL) {
   if (any(is.na(autor_info$uri)) |
       .check_autor_poder_executivo(autor_info) |
       .check_autor_senado_federal(autor_info) |
-      .check_autor_legislacao_participativa(autor_info)) {
+      .check_autor_comissao(autor_info)) {
     
     autores <- .camara_api(autor_uri) %>%
       .assert_dataframe_completo(.COLNAMES_AUTORES) %>%
@@ -963,20 +963,20 @@ scrap_autores_from_website <- function(id_prop) {
   return(autor_senado_federal != 0)
 }
 
-#' @title Checks whether the participatory legislation commission is the author of the bill
-#' @description Checks whether the participatory legislation commission is the author of the bill
+#' @title Checks whether the commission is the author of the bill
+#' @description Checks whether the commission is the author of the bill
 #' @param autor_info Dataframe with information about the author
-#' @return True if the participatory legislation commission is the author of the proposition and FALSE otherwise
+#' @return True if the commission is the author of the proposition and FALSE otherwise
 #' @examples
 #' autor_uri <- paste0(.CAMARA_PROPOSICOES_PATH, '/', 2203836, "/autores")
 #' autor_info <- .camara_api(autor_uri)
-#' .check_autor_legislacao_participativa(autor_info)
-.check_autor_legislacao_participativa <- function(autor_info) {
-  autor_legislacao_participativa <- autor_info %>%
-    dplyr::filter(stringr::str_detect(tolower(nome), .COMISSAO_LEGISLACAO_PARTICIPATIVA)) %>%
+#' .check_autor_comissao(autor_info)
+.check_autor_comissao <- function(autor_info) {
+  autor_comissao <- autor_info %>%
+    dplyr::filter(stringr::str_detect(tolower(nome), .COMISSAO)) %>%
     nrow()
   
-  return(autor_legislacao_participativa != 0)
+  return(autor_comissao != 0)
 }
 
 #' @title Fetch the propositions appended to a proposition in the Camara


### PR DESCRIPTION
Conserta a casa origem de proposições do senado.

Mudanças propostas nesse PR:
- Adição de constante _.SENADO_FEDERAL_
- Adição de metodo _.check_autor_senado_federal_