### PR TITLE
Revisão dos regex da câmara: urgencia revisados, incluido "inclusao e…

### DIFF
--- a/R/config/regex_camara.json
+++ b/R/config/regex_camara.json
@@ -1,15 +1,48 @@
 {
-  "eventos": [
-    {"evento": "requerimento_redistribuicao", "regex": "^apresentação do requerimento de redistribuição"},
-    {"evento": "requerimento_apensacao", "regex": "^apresentação do requerimento de apensação"},
-    {"evento": "requerimento_urgencia_apresentado", "regex": "^apresentação do requerimento de urg.ncia"},
-    {"evento": "requerimento_urgencia_aprovado", "regex": "^aprovado o requerimento de urg.ncia|aprovado, por unanimidade, o requerimento de urg.ncia"},
-    {"evento": "requerimento_prorrogacao", "regex": "^apresentação do requerimento de prorrogação de prazo de comissão temporária"},
-    {"evento": "aprovacao_requerimento_inversao_pauta", "regex": "^.*aprovado o requerimento.*invers.o de pauta.*$"},
-    {"evento": "req_apresentacao", "regex": "^apresentacao do requerimento"},
-    {"evento": "req_deferido", "regex": "^deferido(s)* o(s)* requerimento(s)*|deferido requerimento"},
-    {"evento": "req_indeferido", "regex": "^indeferido(s)* o(s)* requerimento(s)*|indeferido req"},
-    {"evento": "req_arquivado", "regex": "^requerimento .*arquivado|^arquivado o requerimento"},
-    {"evento": "req_urgencia_unanime_verbal", "regex": "^.*proposta verbal do presidente.* aprovado.* requerimento de urg.ncia.*$"}
-  ]
+ "eventos": [
+  {
+   "evento": "requerimento_redistribuicao",
+   "regex": "^apresentação do requerimento de redistribuição"
+  },
+  {
+   "evento": "requerimento_apensacao",
+   "regex": "^apresentação do requerimento de apensação"
+  },
+  {
+   "evento": "requerimento_urgencia_apresentado",
+   "regex": "apresentação d[ao] requerimento de urg[eê]ncia"
+  },
+  {
+   "evento": "requerimento_urgencia_aprovado",
+   "regex": "^aprova(?!.*parecer).*(?:urg.ncia|(?:art\\.|artigo) ?155)"
+  },
+  {
+   "evento": "requerimento_prorrogacao",
+   "regex": "^apresentação do requerimento de prorrogação de prazo de comissão temporária"
+  },
+  {
+   "evento": "aprovacao_requerimento_inversao_pauta",
+   "regex": "^.*aprovado o requerimento.*invers.o de pauta.*$"
+  },
+  {
+   "evento": "req_apresentacao",
+   "regex": "^apresentacao do requerimento"
+  },
+  {
+   "evento": "req_deferido",
+   "regex": "^deferido(s)* o(s)* requerimento(s)*|deferido requerimento"
+  },
+  {
+   "evento": "req_indeferido",
+   "regex": "^indeferido(s)* o(s)* requerimento(s)*|indeferido req"
+  },
+  {
+   "evento": "req_arquivado",
+   "regex": "^requerimento .*arquivado|^arquivado o requerimento"
+  },
+  {
+   "evento": "requerimento_inclusao_em_pauta",
+   "regex": "^apresent.*(?:inclusão|incluir?).{1,30}(?:pauta|ordem)"
+  }
+ ]
 }


### PR DESCRIPTION
…m pauta" e retirado "urgencia verbal" (caso excepcional não representativo).

Mudanças propostas nesse PR:

- Aprimorei o regex de detecção de eventos relacionados a requerimentos de urgência
- Adicionei um evento novo;
- Retirei um evento ruim (requerimento de urgência verbal) que só ocorreu uma vez e não é representativo.