### PR TITLE
Fix proposicoes

### DIFF
--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -116,18 +116,19 @@ fetch_proposicao_senado_sigla <- function(sigla, numero, ano) {
     proposicao_data %>%
     magrittr::extract2("PesquisaBasicaMateria") %>%
     magrittr::extract2("Materias") %>%
-    magrittr::extract2("Materia")
+    magrittr::extract2("Materia") %>% 
+    dplyr::as_tibble()
 
-  if ("IdentificacaoMateria.CodigoMateria" %in% names(proposicao_infos)) {
+  if ("Codigo" %in% names(proposicao_infos)) {
     if (nrow(proposicao_infos) > 1) {
       proposicao_infos <- proposicao_infos %>%
-        dplyr::filter(tolower(`IdentificacaoMateria.SiglaSubtipoMateria`) == tolower(sigla)) %>%
+        dplyr::filter(tolower(`Sigla`) == tolower(sigla)) %>%
         head(1)
     }
 
     proposicao_complete <-
       proposicao_infos %>%
-      .rename_senate_propositions_df_columns() %>%
+      .rename_senate_propositions_by_siglas_df_columns() %>% 
       .assert_dataframe_completo(.COLNAMES_PROPOSICAO_SENADO_SIGLA) %>%
       .coerce_types(.COLNAMES_PROPOSICAO_SENADO_SIGLA)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -422,6 +422,27 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(".")
   
   }
 
+#' @title Selects propositions by sigla dataframe's columns
+#' @description Selects dataframe's columns renaming specific columns,
+#  using underscore and lowercase pattern and 
+#' removing unnecessary strings from column names.
+#' @param df Dataframe
+#' @return Dataframe with renamed columns.
+.rename_senate_propositions_by_siglas_df_columns <- function(df) {
+  df <- df %>%
+    dplyr::select(
+      codigo_materia = Codigo,
+      sigla_subtipo_materia = Sigla,
+      numero_materia = Numero,
+      ano_materia = Ano,
+      ementa_materia = Ementa,
+      data_apresentacao = Data,
+      nome_autor = Autor,
+      descricao_identificacao_materia = DescricaoIdentificacao
+    )
+  return(df %>% .rename_senate_propositions_df_columns())
+  
+}
 #' @title Renames a vector with the pattern of underscores and lowercases
 #' @description Renames each item from vector with the pattern: split by underscore and lowercase
 #' @param x Strings vector


### PR DESCRIPTION
# Mudanças:
- Conserta função que retorna os dados de proposição no Senado pela sigla, número e ano. Isso resolve o erro de MPV com id preenchido somente na câmara